### PR TITLE
Add forgotten attr_accessor to inventory_filename

### DIFF
--- a/lib/vai/config.rb
+++ b/lib/vai/config.rb
@@ -2,6 +2,7 @@ module VagrantPlugins
   module Vai
     class Config < Vagrant.plugin("2", :config)
       attr_accessor :inventory_dir
+      attr_accessor :inventory_filename
       attr_accessor :groups
       
       def initialize


### PR DESCRIPTION
I forgot to add the attr_accessor to the inventory_filename attribute.
